### PR TITLE
Provide recursive option in fs.mkdirSync call when creating a snapsho…

### DIFF
--- a/src/getExistingSnaps.js
+++ b/src/getExistingSnaps.js
@@ -6,7 +6,7 @@ module.exports = function(snapshotDir, snapshotFilePath) {
 
   if (!fs.existsSync(snapshotDir)) {
     checkCI();
-    fs.mkdirSync(snapshotDir);
+    fs.mkdirSync(snapshotDir, {recursive: true});
   }
 
   if (fs.existsSync(snapshotFilePath))


### PR DESCRIPTION
The issue:
Without the recursive option, when any folder along the given path is missing, mkdirSync will throw an ENOENT error.

The solution:
Use the recursive option, introduced in v10.12. The only caveat, now this module requires Node v10.12+